### PR TITLE
Feature/fix_local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ WSO2_CLIENT_ID=darts_api_gateway
 WSO2_CLIENT_SECRET=darts_api_gateway_secret
 WSO2_IS_INTROSPECT_USER=admin
 WSO2_IS_INTROSPECT_PASSWORD=admin
+# Default scopes when WSO2 introspection omits scope field (fallback)
+WSO2_IS_DEFAULT_SCOPES="dartboard:write dartboard:read game:write game:control score:write player:write"
 
 # Application Configuration
 SECRET_KEY=your-secret-key-change-in-production

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,24 @@
-# Example environment variables for dartserver-pythonapp
-FLASK_DEBUG=True
-DATABASE_URL=postgresql://user:password@localhost:5432/dartserver
-test_user_token=your_test_token_here
-RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+# WSO2 OAuth2 Configuration
+WSO2_CLIENT_ID=darts_api_gateway
+WSO2_CLIENT_SECRET=darts_api_gateway_secret
+WSO2_IS_INTROSPECT_USER=admin
+WSO2_IS_INTROSPECT_PASSWORD=admin
+
+# Application Configuration
+SECRET_KEY=your-secret-key-change-in-production
+FLASK_DEBUG=False
+FLASK_ENV=development
+
+# Database Configuration
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/dartsdb
+
+# RabbitMQ Configuration
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_PORT=5672
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest
+RABBITMQ_VHOST=/
+RABBITMQ_EXCHANGE=darts_exchange
+
+# Logging
+LOG_LEVEL=INFO

--- a/.github/agents/my-agent.md
+++ b/.github/agents/my-agent.md
@@ -6,4 +6,9 @@ description: Coding companion for the dartserver application and infrastructure
 # My Agent
 
 - Create PR's from assigned tasks and issues
--
+- Always run tests after making code changes
+- Follow best practices for code quality and maintainability
+- always test the pre-commit linting and formatting checks after making code changes
+- always create unit tests for new code and features, and run all tests before creating a PR
+- before removing docker volumes, check if they contain any important data and back it up if necessary
+- when working with docker, always check the logs for any errors or issues that may arise

--- a/alembic/versions/a1b2c3d4e5f6_add_master_slave_pins_to_dartboard_type.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_master_slave_pins_to_dartboard_type.py
@@ -14,10 +14,45 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column("dartboard_type", sa.Column("master_pins", sa.Text(), nullable=True))
-    op.add_column("dartboard_type", sa.Column("slave_pins", sa.Text(), nullable=True))
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("dartboard_type"):
+        op.create_table(
+            "dartboard_type",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("name", sa.String(length=100), nullable=False),
+            sa.Column("brand", sa.String(length=100), nullable=False),
+            sa.Column("model", sa.String(length=100), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("is_active", sa.Boolean(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("master_pins", sa.Text(), nullable=True),
+            sa.Column("slave_pins", sa.Text(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("name"),
+        )
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("dartboard_type")}
+
+    if "master_pins" not in columns:
+        op.add_column("dartboard_type", sa.Column("master_pins", sa.Text(), nullable=True))
+    if "slave_pins" not in columns:
+        op.add_column("dartboard_type", sa.Column("slave_pins", sa.Text(), nullable=True))
 
 
 def downgrade():
-    op.drop_column("dartboard_type", "slave_pins")
-    op.drop_column("dartboard_type", "master_pins")
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("dartboard_type"):
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("dartboard_type")}
+
+    if "slave_pins" in columns:
+        op.drop_column("dartboard_type", "slave_pins")
+    if "master_pins" in columns:
+        op.drop_column("dartboard_type", "master_pins")

--- a/alembic/versions/b2c3d4e5f6a7_add_dartboard_zone_mapping_table.py
+++ b/alembic/versions/b2c3d4e5f6a7_add_dartboard_zone_mapping_table.py
@@ -1,0 +1,63 @@
+"""add_dartboard_zone_mapping_table
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-02 20:20:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("dartboard_zone_mapping"):
+        op.create_table(
+            "dartboard_zone_mapping",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("dartboard_type_id", sa.Integer(), nullable=False),
+            sa.Column("master_pin", sa.Integer(), nullable=False),
+            sa.Column("slave_pin", sa.Integer(), nullable=False),
+            sa.Column("zone_number", sa.Integer(), nullable=False),
+            sa.Column("multiplier_type", sa.String(length=20), nullable=False),
+            sa.Column("base_value", sa.Integer(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(["dartboard_type_id"], ["dartboard_type.id"]),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    indexes = {index["name"] for index in inspector.get_indexes("dartboard_zone_mapping")}
+    if "ix_dartboard_zone_mapping_dartboard_type_id" not in indexes:
+        op.create_index(
+            "ix_dartboard_zone_mapping_dartboard_type_id",
+            "dartboard_zone_mapping",
+            ["dartboard_type_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if inspector.has_table("dartboard_zone_mapping"):
+        indexes = {index["name"] for index in inspector.get_indexes("dartboard_zone_mapping")}
+        if "ix_dartboard_zone_mapping_dartboard_type_id" in indexes:
+            op.drop_index(
+                "ix_dartboard_zone_mapping_dartboard_type_id",
+                table_name="dartboard_zone_mapping",
+            )
+        op.drop_table("dartboard_zone_mapping")

--- a/doc/CONFIG_REPOSITORY_REQUIREMENTS.md
+++ b/doc/CONFIG_REPOSITORY_REQUIREMENTS.md
@@ -1,0 +1,226 @@
+# Configuration Repository Requirements
+
+This document outlines the required environment variables that must be configured in the `dartserver-config` repository for each deployment environment.
+
+## Overview
+
+The deployment pipeline pulls environment-specific configuration from the private `dartserver-config` repository. Configuration files are stored in:
+- `environments/test/.env` - Test environment
+- `environments/production/.env` - Production environment
+
+## Required Environment Variables
+
+### WSO2 Identity Server Configuration
+
+#### WSO2_IS_CLIENT_ID
+- **Description**: OAuth2 client ID for the API Gateway service
+- **Default**: `darts_api_gateway`
+- **Required**: Yes
+- **Example**: `darts_api_gateway`
+
+#### WSO2_IS_CLIENT_SECRET
+- **Description**: OAuth2 client secret for the API Gateway service
+- **Required**: Yes
+- **Security**: Store securely in encrypted config repository
+- **Example**: `darts_api_gateway_secret`
+
+#### WSO2_IS_INTROSPECT_USER
+- **Description**: Admin username for token introspection API calls
+- **Default**: `admin`
+- **Required**: Yes
+- **Example**: `admin`
+
+#### WSO2_IS_INTROSPECT_PASSWORD
+- **Description**: Admin password for token introspection API calls
+- **Required**: Yes
+- **Security**: Store securely in encrypted config repository
+- **Example**: `admin`
+
+#### WSO2_IS_DEFAULT_SCOPES
+- **Description**: Default OAuth2 scopes to apply when WSO2 token introspection omits the scope field
+- **Required**: Yes (as of PR #182)
+- **Format**: Space-separated or comma-separated list of scopes
+- **Default**: `"dartboard:write dartboard:read game:write game:control score:write player:write"`
+- **Purpose**: 
+  - Fallback when WSO2 introspection returns tokens without scope field
+  - Only applied when `client_id` matches `WSO2_IS_CLIENT_ID`
+  - Enables scope-based authorization even when introspection omits scopes
+- **Example**: 
+  ```dotenv
+  WSO2_IS_DEFAULT_SCOPES="dartboard:write dartboard:read game:write game:control score:write player:write"
+  ```
+
+### Application Configuration
+
+#### SECRET_KEY
+- **Description**: Flask session encryption secret key
+- **Required**: Yes
+- **Security**: Generate unique cryptographically random value per environment
+- **Example**: Use `python -c "import secrets; print(secrets.token_hex(32))"`
+
+#### TTS_ENABLED
+- **Description**: Enable/disable text-to-speech announcements
+- **Default**: `true`
+- **Values**: `true` or `false`
+
+#### TTS_ENGINE
+- **Description**: Text-to-speech engine to use
+- **Default**: `gtts`
+- **Options**: `gtts`, `espeak`, `festival`
+
+### Database Configuration
+
+#### DATABASE_URL
+- **Description**: PostgreSQL connection string
+- **Required**: Yes
+- **Format**: `postgresql://user:password@host:port/database`
+- **Example**: `postgresql://postgres:postgres@postgres:5432/dartsdb`
+
+### RabbitMQ Configuration
+
+#### RABBITMQ_EXCHANGE
+- **Description**: RabbitMQ exchange name for message routing
+- **Required**: Yes
+- **Example**: `darts_exchange`
+
+## Configuration Template
+
+### Test Environment (.env)
+
+```dotenv
+# Environment
+ENVIRONMENT=test
+APP_DOMAIN=test.letsplaydarts.eu
+APP_SCHEME=https
+FLASK_USE_SSL=True
+FLASK_DEBUG=False
+
+# WSO2 Identity Server
+WSO2_CLIENT_ID=darts_api_gateway
+WSO2_CLIENT_SECRET=<ENCRYPTED_SECRET>
+WSO2_IS_INTROSPECT_USER=admin
+WSO2_IS_INTROSPECT_PASSWORD=<ENCRYPTED_PASSWORD>
+WSO2_IS_DEFAULT_SCOPES="dartboard:write dartboard:read game:write game:control score:write player:write"
+WSO2_IS_URL=https://test.letsplaydarts.eu/auth
+WSO2_IS_VERIFY_SSL=False
+
+# Application
+SECRET_KEY=<GENERATED_SECRET_KEY>
+SESSION_COOKIE_SECURE=True
+AUTH_DISABLED=false
+
+# Database
+DATABASE_URL=postgresql://postgres:<PASSWORD>@postgres:5432/dartsdb
+
+# RabbitMQ
+RABBITMQ_EXCHANGE=darts_exchange
+RABBITMQ_TOPIC=darts.#
+
+# TTS
+TTS_ENABLED=true
+TTS_ENGINE=gtts
+TTS_LANGUAGE=nl
+```
+
+### Production Environment (.env)
+
+```dotenv
+# Environment
+ENVIRONMENT=production
+APP_DOMAIN=letsplaydarts.eu
+APP_SCHEME=https
+FLASK_USE_SSL=True
+FLASK_DEBUG=False
+
+# WSO2 Identity Server
+WSO2_CLIENT_ID=darts_api_gateway
+WSO2_CLIENT_SECRET=<ENCRYPTED_SECRET>
+WSO2_IS_INTROSPECT_USER=admin
+WSO2_IS_INTROSPECT_PASSWORD=<ENCRYPTED_PASSWORD>
+WSO2_IS_DEFAULT_SCOPES="dartboard:write dartboard:read game:write game:control score:write player:write"
+WSO2_IS_URL=https://letsplaydarts.eu/auth
+WSO2_IS_VERIFY_SSL=True
+
+# Application
+SECRET_KEY=<GENERATED_SECRET_KEY>
+SESSION_COOKIE_SECURE=True
+AUTH_DISABLED=false
+
+# Database
+DATABASE_URL=postgresql://postgres:<PASSWORD>@postgres:5432/dartsdb
+
+# RabbitMQ
+RABBITMQ_EXCHANGE=darts_exchange
+RABBITMQ_TOPIC=darts.#
+
+# TTS
+TTS_ENABLED=true
+TTS_ENGINE=gtts
+TTS_LANGUAGE=nl
+```
+
+## Migration Guide for PR #182
+
+### What Changed
+
+PR #182 introduces robust OAuth2 scope handling to fix "Insufficient permissions" errors when WSO2 Identity Server introspection omits the `scope` field in token responses.
+
+### Required Actions
+
+**Before deploying to test or production**, add the following to your environment `.env` files in the `dartserver-config` repository:
+
+```dotenv
+WSO2_IS_DEFAULT_SCOPES="dartboard:write dartboard:read game:write game:control score:write player:write"
+```
+
+### Why This Is Needed
+
+1. **WSO2 Behavior**: WSO2 Identity Server 7.x sometimes omits the `scope` field in introspection responses, particularly for client credentials grants
+2. **Fallback Mechanism**: The code now falls back to `WSO2_IS_DEFAULT_SCOPES` when:
+   - Token introspection succeeds (`active: true`)
+   - Client ID matches `WSO2_IS_CLIENT_ID`
+   - No scope field is present in the introspection response
+3. **Environment Flexibility**: Each environment can define its own default scope set based on security requirements
+
+### Deployment Impact
+
+| Configuration Status | Deployment Behavior |
+|---------------------|---------------------|
+| Variable not set | Uses hardcoded default (works but not customizable) |
+| Variable set in .env | Uses environment-specific scopes (recommended) |
+| WSO2 returns scopes | Uses actual scopes from introspection (preferred) |
+
+### Testing the Configuration
+
+After deployment, verify scope handling:
+
+```bash
+# 1. Request token with specific scope
+TOKEN=$(curl -ks -X POST https://<domain>/oauth2/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=client_credentials' \
+  -d 'client_id=darts_api_gateway' \
+  -d 'client_secret=<secret>' \
+  -d 'scope=score:write' | jq -r '.access_token')
+
+# 2. Test authorized endpoint
+curl -X POST https://<domain>/api/v1/scores \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"player_id":"test","score":180,"multiplier":3,"segment":20}'
+
+# Expected: 200 OK with {"status":"success",...}
+```
+
+## Related Documentation
+
+- [WSO2 API Manager Configuration](WSO2_APIM_CONFIGURATION.md)
+- [Deployment Guide](DEPLOYMENT.md)
+- [Security Guide](SECURITY.md)
+
+## Support
+
+For questions or issues with configuration:
+1. Check deployment logs: `docker-compose logs api-gateway`
+2. Verify introspection response format in logs
+3. Review PR #182 for technical details on scope handling

--- a/docker-compose-localhost.yml
+++ b/docker-compose-localhost.yml
@@ -13,6 +13,7 @@ services:
       POSTGRES_DB: dartsdb
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init-postgres-wso2.sql:/docker-entrypoint-initdb.d/01-init-wso2-dbs.sql:ro
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s
@@ -123,8 +124,8 @@ services:
       WSO2_IS_URL: https://localhost:9443
       # Internal Docker network URL for backend calls from the api-gateway container
       WSO2_IS_INTERNAL_URL: https://darts-wso2is:9443
-      WSO2_IS_CLIENT_ID: ${WSO2_CLIENT_ID:-qGUe7mARfB_rbEn09jWJtTyi9uMa}
-      WSO2_IS_CLIENT_SECRET: ${WSO2_CLIENT_SECRET:-HUgKyYNsXxfGAYHb2SYMFuX18Gmu9R9kE99EQkXOfKka}
+      WSO2_IS_CLIENT_ID: ${WSO2_CLIENT_ID:-darts_api_gateway}
+      WSO2_IS_CLIENT_SECRET: ${WSO2_CLIENT_SECRET:-darts_api_gateway_secret}
 
       # Introspection credentials (required for token validation)
       WSO2_IS_INTROSPECT_USER: ${WSO2_IS_INTROSPECT_USER:-admin}
@@ -207,8 +208,8 @@ services:
       WSO2_IS_URL: https://localhost:9443
       # WSO2_IS_INTERNAL_URL: Internal Docker network URL for backend API calls
       WSO2_IS_INTERNAL_URL: https://darts-wso2is:9443
-      WSO2_CLIENT_ID: ${WSO2_CLIENT_ID:-your_client_id_here}
-      WSO2_CLIENT_SECRET: ${WSO2_CLIENT_SECRET:-your_client_secret_here}
+      WSO2_CLIENT_ID: ${WSO2_CLIENT_ID:-darts_api_gateway}
+      WSO2_CLIENT_SECRET: ${WSO2_CLIENT_SECRET:-darts_api_gateway_secret}
       # Match nginx-facing HTTPS origin for local dev callbacks
       WSO2_REDIRECT_URI: ${WSO2_REDIRECT_URI:-https://localhost/callback}
       WSO2_POST_LOGOUT_REDIRECT_URI: ${WSO2_POST_LOGOUT_REDIRECT_URI:-https://localhost/}

--- a/docker-compose-wso2.yml
+++ b/docker-compose-wso2.yml
@@ -13,6 +13,7 @@ services:
       POSTGRES_DB: dartsdb
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init-postgres-wso2.sql:/docker-entrypoint-initdb.d/01-init-wso2-dbs.sql:ro
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/docker-compose-wso2.yml
+++ b/docker-compose-wso2.yml
@@ -115,6 +115,9 @@ services:
       WSO2_IS_INTROSPECT_USER: ${WSO2_IS_INTROSPECT_USER:-admin}
       WSO2_IS_INTROSPECT_PASSWORD: ${WSO2_IS_INTROSPECT_PASSWORD:-admin}
 
+      # Default scopes when introspection omits scope field
+      WSO2_IS_DEFAULT_SCOPES: ${WSO2_IS_DEFAULT_SCOPES:-dartboard:write dartboard:read game:write game:control score:write player:write}
+
       # JWT Validation Mode: 'jwks' or 'introspection'
       JWT_VALIDATION_MODE: introspection
 

--- a/helpers/configure_wso2_gateway_client.py
+++ b/helpers/configure_wso2_gateway_client.py
@@ -142,9 +142,12 @@ def main() -> int:  # noqa: PLR0911
     if resp.status_code == 200:
         client = resp.json()
         print("Found existing client configuration")
-    elif resp.status_code == 404:
+    elif resp.status_code in (401, 403, 404):
         client = None
-        print("Client not found, will attempt to create")
+        print(
+            "Client lookup unavailable or not found "
+            f"(status {resp.status_code}); will attempt to create",
+        )
     else:
         print(f"Failed to fetch client: {resp.status_code} {resp.text}")
         return 4
@@ -183,8 +186,8 @@ def main() -> int:  # noqa: PLR0911
         # ensure required fields for creation
         payload = {
             "client_name": os.getenv("SWAGGER_CLIENT_NAME", "DartsApiGateway"),
-            "client_id": client_id,
-            "client_secret": client_secret or "",
+            "ext_param_client_id": client_id,
+            "ext_param_client_secret": client_secret or "",
             "grant_types": desired["grant_types"],
             "redirect_uris": desired.get("redirect_uris", []),
             "token_endpoint_auth_method": desired.get("token_endpoint_auth_method"),
@@ -192,8 +195,25 @@ def main() -> int:  # noqa: PLR0911
         print("Registering new client via DCR...")
         r = dcr_post(wso2_is_url, payload, admin_user, admin_pass)
         if r.status_code not in (200, 201):
-            print(f"Failed to register client: {r.status_code} {r.text}")
-            return 5
+            if client_secret:
+                print(
+                    "DCR create failed "
+                    f"({r.status_code}); checking whether client already exists",
+                )
+                token_check = request_token(
+                    wso2_is_url,
+                    client_id,
+                    client_secret,
+                    args.scope,
+                )
+                if token_check.status_code == 200:
+                    print("Client already usable; continuing")
+                else:
+                    print(f"Failed to register client: {r.status_code} {r.text}")
+                    return 5
+            else:
+                print(f"Failed to register client: {r.status_code} {r.text}")
+                return 5
         print("Client registered")
     else:
         print("Updating existing client via DCR...")

--- a/init-postgres-wso2.sql
+++ b/init-postgres-wso2.sql
@@ -1,0 +1,11 @@
+-- Initialize PostgreSQL databases for WSO2 Identity Server
+-- This script is automatically run when PostgreSQL container starts
+
+-- Create WSO2 Identity database
+CREATE DATABASE wso2is_identity WITH ENCODING 'UTF8';
+
+-- Create WSO2 Shared database
+CREATE DATABASE wso2is_shared WITH ENCODING 'UTF8';
+
+-- Create WSO2 API Manager database
+CREATE DATABASE wso2apim_shared WITH ENCODING 'UTF8';

--- a/packages/dartserver-app/src/dartserver_app/multi_game_manager.py
+++ b/packages/dartserver-app/src/dartserver_app/multi_game_manager.py
@@ -121,11 +121,11 @@ class MultiGameManager:
         games_list = []
         for game_id, game_manager in self.games.items():
             state = game_manager.get_game_state()
-            
+
             # Skip finished games
             if state.get("is_finished"):
                 continue
-                
+
             players = state.get("players", [])
 
             # Prefer authoritative player list from game_data replay when present

--- a/src/api_gateway/app.py
+++ b/src/api_gateway/app.py
@@ -57,6 +57,11 @@ WSO2_IS_CLIENT_SECRET = os.getenv("WSO2_IS_CLIENT_SECRET", "")
 WSO2_IS_INTROSPECT_USER = os.getenv("WSO2_IS_INTROSPECT_USER", "admin")
 WSO2_IS_INTROSPECT_PASSWORD = os.getenv("WSO2_IS_INTROSPECT_PASSWORD", "admin")
 WSO2_IS_VERIFY_SSL = os.getenv("WSO2_IS_VERIFY_SSL", "False").lower() == "true"
+WSO2_IS_DEFAULT_SCOPES = os.getenv(
+    "WSO2_IS_DEFAULT_SCOPES",
+    "openid profile email dartboard:write dartboard:read "
+    "game:write game:control score:write player:write",
+)
 
 # RabbitMQ Configuration
 RABBITMQ_CONFIG = {
@@ -196,6 +201,33 @@ class _LazyRabbitMQPublisher:
 rabbitmq_publisher: _LazyRabbitMQPublisher = _LazyRabbitMQPublisher(RABBITMQ_CONFIG)
 
 
+def _normalize_scopes(*scope_sources: Any) -> set[str]:
+    """Normalize mixed scope representations into a canonical set."""
+    normalized_scopes: set[str] = set()
+    for source in scope_sources:
+        if not source:
+            continue
+        if isinstance(source, str):
+            chunks = source.replace(",", " ").split()
+            normalized_scopes.update(scope for scope in chunks if scope)
+            continue
+        if isinstance(source, (list, tuple, set)):
+            for item in source:
+                if isinstance(item, str):
+                    chunks = item.replace(",", " ").split()
+                    normalized_scopes.update(scope for scope in chunks if scope)
+    return normalized_scopes
+
+
+def _extract_claim_scopes(claims: dict[str, Any]) -> set[str]:
+    """Extract scopes from common claim keys used by OAuth/OIDC providers."""
+    return _normalize_scopes(
+        claims.get("scope"),
+        claims.get("scopes"),
+        claims.get("scp"),
+    )
+
+
 def validate_jwt_token(token: str) -> dict[str, Any] | None:
     """
     Validate JWT token using JWKS or introspection
@@ -246,18 +278,20 @@ def validate_jwt_token(token: str) -> dict[str, Any] | None:
                         f"Token validated via introspection for client: "
                         f"{introspection_result.get('client_id', 'unknown')}",
                     )
-                    # WSO2 introspection may not return scopes,
-                    # so add them from configured client scopes
-                    # Map of client_id -> scopes for clients created via DCR
-                    client_scopes = {
-                        "qGUe7mARfB_rbEn09jWJtTyi9uMa": (
-                            "openid profile email dartboard:write dartboard:read "
-                            "game:write game:control score:write player:write"
-                        ),
-                    }
                     client_id = introspection_result.get("client_id", "")
-                    if "scope" not in introspection_result and client_id in client_scopes:
-                        introspection_result["scope"] = client_scopes[client_id]
+                    scopes = _extract_claim_scopes(introspection_result)
+                    if (
+                        not scopes
+                        and client_id
+                        and WSO2_IS_CLIENT_ID
+                        and client_id == WSO2_IS_CLIENT_ID
+                    ):
+                        default_scopes = _normalize_scopes(WSO2_IS_DEFAULT_SCOPES)
+                        if default_scopes:
+                            introspection_result["scope"] = " ".join(sorted(default_scopes))
+                            scopes = default_scopes
+                    if scopes:
+                        introspection_result["scope"] = " ".join(sorted(scopes))
                     result = introspection_result
                 else:
                     logger.warning(f"Token is not active: {introspection_result}")
@@ -325,7 +359,7 @@ def require_auth(required_scopes: list | None = None):
 
             # Check required scopes
             if required_scopes:
-                token_scopes = claims.get("scope", "").split()
+                token_scopes = _extract_claim_scopes(claims)
                 if not any(scope in token_scopes for scope in required_scopes):
                     return (
                         jsonify(

--- a/tests/unit/test_api_gateway.py
+++ b/tests/unit/test_api_gateway.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+import src.api_gateway.app as gateway_module
 from src.api_gateway.app import app as gateway_app
 from src.api_gateway.app import rabbitmq_publisher
 
@@ -491,3 +492,48 @@ class TestOpenAPIEndpoints:
         response = client.get("/api-docs")
         assert response.status_code == 200
         assert b"swagger-ui" in response.data
+
+
+class TestAuthorizationScopes:
+    """Test authorization scope parsing and fallback behavior"""
+
+    def test_submit_score_accepts_comma_separated_scope(self, client, mock_rabbitmq):
+        """Token scope provided as comma-separated string should be accepted"""
+        with patch("src.api_gateway.app.validate_jwt_token") as mock_validate:
+            mock_validate.return_value = {
+                "sub": "test-user",
+                "client_id": "dartboard-001",
+                "scope": "score:write,game:write",
+            }
+
+            response = client.post(
+                "/api/v1/scores",
+                json={"score": 15, "multiplier": "SINGLE"},
+                headers={"Authorization": "Bearer test-token-123"},
+                content_type="application/json",
+            )
+
+        assert response.status_code == 201
+
+    def test_introspection_uses_default_scopes_for_configured_client(self):
+        """Configured client should receive default scopes when introspection omits scopes"""
+
+        class MockResponse:
+            status_code = 200
+            text = '{"active": true, "client_id": "darts_api_gateway"}'
+
+            @staticmethod
+            def json():
+                return {"active": True, "client_id": "darts_api_gateway"}
+
+        with (
+            patch("src.api_gateway.app.JWT_VALIDATION_MODE", "introspection"),
+            patch("src.api_gateway.app.WSO2_IS_CLIENT_ID", "darts_api_gateway"),
+            patch("src.api_gateway.app.WSO2_IS_DEFAULT_SCOPES", "score:write game:write"),
+            patch("src.api_gateway.app.requests.post", return_value=MockResponse()),
+        ):
+            claims = gateway_module.validate_jwt_token("opaque-test-token")
+
+        assert claims is not None
+        assert "score:write" in claims["scope"]
+        assert "game:write" in claims["scope"]


### PR DESCRIPTION
- Add scope normalization supporting multiple claim keys (scope, scopes, scp)
- Handle comma-separated and space-separated scope formats
- Implement fallback to WSO2_IS_DEFAULT_SCOPES when introspection omits scopes
- Add unit tests for comma-separated scopes and introspection fallback
- Resolves 'Insufficient permissions' error when WSO2 introspection returns no scope field